### PR TITLE
Fix: Add fallback selector for TikTok HTML structure changes

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -176,8 +176,9 @@ clean_names <- function(x) {
 #' @noRd
 extract_urls_sess <- function(sess) {
   # TODO: also extract slideshows
-  rvest::html_elements(sess, "[id*='column-item-video-container'] a") |>
+  rvest::html_elements(sess, "[id*='grid-item-container'] a, [id*='column-item-video-container'] a") |>
     rvest::html_attr("href") |>
+    unique() |>
     grep(pattern = "/video/|/photo/", x = _, value = TRUE)
 }
 


### PR DESCRIPTION
TikTok changed element IDs from 'column-item-video-container' to 'grid-item-container'. This update queries both selectors to ensure compatibility with old and new page structures.